### PR TITLE
Remove andrewrk/zig-general-purpose-allocator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,6 @@
 - [v1zix/zig-string](https://github.com/v1zix/zig-string) Strings for Zig
 
 ## Allocators
-- [andrewrk/zig-general-purpose-allocator](https://github.com/andrewrk/zig-general-purpose-allocator) work-in-progress general purpose allocator intended to be eventually merged into Zig standard library. live streamed development
 - [dbandstra/zig-hunk](https://github.com/dbandstra/zig-hunk) Basic stack allocator for Zig
 - [fengb/zee_alloc](https://github.com/fengb/zee_alloc) tiny Zig allocator primarily targeting WebAssembly
 - [mdsteele/ziegfried](https://github.com/mdsteele/ziegfried) A general-purpose memory allocator for Zig


### PR DESCRIPTION
This repository has been upstreamed into the Zig standard library so it's existence in this list now seems more like noise.
