### PR TITLE
Add jsmn_zig JSON tokenizer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,7 @@
 ## Parser
 - [darithorn/zig-toml](https://github.com/darithorn/zig-toml) A TOML parser written in Zig
 - [ducdetronquito/hppy](https://github.com/ducdetronquito/hppy) The happy HTML parser ᕕ( ᐛ )ᕗ
+- [Ferki-git-creator/jsmn_zig](https://github.com/Ferki-git-creator/jsmn_zig) JSMN-inspired JSON tokenizer with 4-byte compact tokens (80% memory savings), zero-copy streaming, and hybrid stack/heap allocation
 - [gernest/url](https://github.com/gernest/url)
 - [goto-bus-stop/ziguid](https://github.com/goto-bus-stop/ziguid) GUID parsing/stringifying with zig
 - [Hejsil/zig-clap](https://github.com/Hejsil/zig-clap) Simple command line argument parsing library


### PR DESCRIPTION
## Add jsmn_zig - Memory-efficient JSON tokenizer

**jsmn_zig** is a Zig port of JSMN with significant improvements:

### Key Features:
- **4-byte compact tokens** (vs 20+ bytes in standard tokens - 80% memory savings)
- **Zero-copy streaming** with proper state management
- **Hybrid memory allocation** - auto-switches between stack/heap
- **SIMD-ready optimizations** for x86/ARM
- **Comptime-configurable** for embedded use

### Perfect for:
- Embedded systems where memory matters
- High-performance JSON parsing
- Network protocol implementations
- Configuration file parsing

The library maintains JSMN's simplicity while leveraging Zig's comptime power and memory safety.